### PR TITLE
Edit recipes

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -277,6 +277,26 @@
             </div>
         </section>
 
+        <!-- Edit Recipe Section-->
+        <div class="edit-recipe-form">
+            <h1> Edit Recipe </h1>
+            <div class="edit-ingredients">
+              <h3>Ingredients</h3>
+              <ol>
+              </ol>
+              <button onclick="addMoreIngredients()">Add more</button>
+            </div>
+            <div class="edit-instructions">
+              <h3>Instructions </h3>
+              <ol>
+              </ol>
+              <button onclick="addMoreInstructions()">Add more</button>
+            </div>
+            <div>
+              <button id="cancel" onclick="toggleEditRecipe()">Cancel </button>
+              <button id="submit" onclick="submit()">Save </button>
+            </div>
+        </div>
 
      
     </main>

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -35,12 +35,24 @@ class RecipePage extends HTMLElement{
         #instructions {
           width: auto;
         }
+        
         .middle{
           display: block;
           text-align: center; 
           width: 50%;
           margin: auto;
         }
+      }
+
+      .edit-recipe {
+        padding: 1em;
+        display: grid;
+        place-items: center;
+      }
+      
+      .edit-recipe > span:hover {
+        cursor: pointer;
+        color: #FF9E44;
       }
     
       .middle > div > h3{
@@ -169,6 +181,10 @@ class RecipePage extends HTMLElement{
         font-size: 1rem;
       }
 
+      .hidden {
+        display: none;
+      }
+
       #prev-step-button {
         margin-right: 2vw;
       }
@@ -190,6 +206,9 @@ class RecipePage extends HTMLElement{
         <h1></h1>
         <img id="bookmark" onclick="showCookBookMenu()" src="img/icons/bookmark-empty.svg" name="bookmark-empty" width="56" height="56">
       </header>
+      <div class="edit-recipe hidden">
+        <span onclick="load()">Edit <img src="./img/icons/pencil.svg" alt="pencil" width="20" height="20"> </span>
+      </div>
       <main class="middle">
         <img style="display: block; margin-left: auto; margin-right: auto;">
           <div id="ingredients-list">
@@ -221,6 +240,9 @@ class RecipePage extends HTMLElement{
         <h1></h1>
         <img id="bookmark" onclick="showCookBookMenu()" src="./img/icons/bookmark-empty.svg" name="bookmark-empty" width="56" height="56">
       </header>
+      <div class="edit-recipe hidden">
+        <span onclick="load()">Edit <img src="./img/icons/pencil.svg" alt="pencil" width="20" height="20"> </span>
+      </div>
       <main id="recipe-page-box" class="middle">
         <img style="display: block; margin-left: auto; margin-right: auto;" >
           <div id="ingredients-list">
@@ -369,9 +391,12 @@ function getIngredients(data){
  * @returns {Array} return a list of instructions
  */
 function getInstructions(data){
-  const steps = data["analyzedInstructions"][0]["steps"];
-  // called from cookbook
-  if (steps == null || steps == undefined) { return data["instructions"]; }
+  let steps = [];
+  try { 
+    steps = data["analyzedInstructions"][0]["steps"]; // Data from API
+  } catch {
+    return data["instructions"]; // Data from Local Storage
+  }
   let instrucList = [];
   let index = 0;
 

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -31,11 +31,16 @@ class RecipePage extends HTMLElement{
         z-index: 100;
       }
 
-      .middle{
-        display: block;
-        text-align: center;
-        width: 50%;
-        margin: auto;
+      @media (min-width: 750px) {
+        #instructions {
+          width: auto;
+        }
+        .middle{
+          display: block;
+          text-align: center; 
+          width: 50%;
+          margin: auto;
+        }
       }
     
       .middle > div > h3{
@@ -96,24 +101,30 @@ class RecipePage extends HTMLElement{
       /*-----------------------------------*/
       
       #instructions{
-        width: auto;
+        width: 100%;
         display: inline-block; 
         text-align: left;
       }
+      
+      #instructions > h3 {
+        text-align: center;
+      }
+      
       
       #instructions > ol > li{
         color: black;
       }
       
       #ingredients-list{
+      
         font-style: normal;
         font-weight: normal;
       }
       
-      #ingredients-list > ul{
-        width: auto;
-        display: inline-block; 
-        text-align: left;
+       #ingredients-list > ul{
+         width: auto;
+         display: inline-block; 
+         text-align: left;
       }
       
       #ingredients-list > button{

--- a/source/scripts/api_script.js
+++ b/source/scripts/api_script.js
@@ -12,7 +12,7 @@
 
 //Set API_URL
 const MAIN_API_URL = "https://api.spoonacular.com/recipes";
-const API_KEY = "&apiKey=fafd5e810c304ed3b4f9984672cb21ee&";
+const API_KEY = "&apiKey=c8f83bb3a9af4355b12de10250b24c88&";
 // API_KEY5: dd38d96d1f5d410f9bf7bfcef6cede83
 // API_KEY4 (Nhi): 8aaa6b0816db4a99b92e7852d125a9aa
 // API_KEY3 (Nhi): c8f83bb3a9af4355b12de10250b24c88

--- a/source/scripts/main.js
+++ b/source/scripts/main.js
@@ -374,13 +374,19 @@ function addNewCookBook() {
 /* end of save new cookbook ====================================================*/
 
 /* Edit Recipe functions ====================================================*/
+
+
 let EDIT_RECIPE_DATA = {}; // data from current recipe
+/**
+ * This function loads all ingredients and instructions to the Edit Recipe popup
+ */
 function load() {
     const Id = document.querySelector("recipe-page").data["id"];
     EDIT_RECIPE_DATA = JSON.parse(localStorage.getItem(`ID-${Id}`));
     const Ingredients = EDIT_RECIPE_DATA["ingredients"];
     const Instructions = EDIT_RECIPE_DATA["instructions"];
-    // remove all elements in case user clicks it twice <= potential bug
+
+    // remove all elements in case user clicks it twice
     let ingreList = document.querySelectorAll(".edit-recipe-form > .edit-ingredients > ol > li");
     let instrList = document.querySelectorAll(".edit-recipe-form > .edit-instructions > ol > li");
     if (ingreList.length !== 0) { ingreList.forEach(e => e.remove()) }
@@ -437,7 +443,7 @@ function addMoreIngredients(ig = "") {
 
 /**
  * This hepler function adds instructions to the edit recipe
- * @param {string} ins 
+ * @param {string} ins instruction
  */
 function addMoreInstructions(ins = "") {
     let li = document.createElement("li");

--- a/source/scripts/main.js
+++ b/source/scripts/main.js
@@ -263,7 +263,7 @@ function showCookBookMenu() {
         }
         toggleSaveCookBook();
     }
-    else {
+    else if (confirm("Are you sure to remove this recipe?")) {
         try {
             // remove recipe data from local storage and cook book
             const Data = document.querySelector("recipe-page").data;
@@ -292,7 +292,6 @@ function bindNewCookBook(li) {
     li.addEventListener("click", (event) => {
         try {
             // save recipe data to local storage and add it to the 
-            alert(event.currentTarget.innerText);
             const CookBookName = event.currentTarget.innerText; // cookbook that user chooses
             let bookMark = document.querySelector("#recipe-page-container > recipe-page").shadowRoot.querySelector("#bookmark");
             const Data = document.querySelector("recipe-page").data;

--- a/source/scripts/main.js
+++ b/source/scripts/main.js
@@ -162,12 +162,12 @@ function hideCategoryCards() {
     categoryCards.style.display = "none";
 }
 
-function showTapMode(){
+function showTapMode() {
     const tap = document.getElementById("tap-mode-button");
     tap.style.visibility = "visible";
 }
 
-function hideTapMode(){
+function hideTapMode() {
     const tap = document.getElementById("tap-mode-button");
     tap.style.visibility = "hidden";
 }
@@ -208,6 +208,8 @@ function updateSettings() {
  * and load data from local storage.
  * @param {Object} data 
  */
+
+// TODO: Add a warning before removing bookmark ("Are you sure to you want to remove this from your Cookbooks? All local edits to the recipe will be lost")
 function checkBookMark(data) {
     const Id = data["id"];
     const Data = JSON.parse(localStorage.getItem(`ID-${Id}`));
@@ -483,7 +485,7 @@ function submit() {
     // reload
     document.querySelector("recipe-page").data = EDIT_RECIPE_DATA;
     showBookMarkEditReipce();
-    
+
     EDIT_RECIPE_DATA = {};
 }
 

--- a/source/scripts/script.js
+++ b/source/scripts/script.js
@@ -75,8 +75,6 @@ async function init() {
             createRecipeCards();
         }
     });
-
-
 }
 
 // The search function, calls API function to fetch all recipes

--- a/source/scripts/script.js
+++ b/source/scripts/script.js
@@ -140,6 +140,7 @@ function createRecipeCards() {
 
         const id = recipeData[i]["id"];
         router.addPage(id, function () {
+            window.scrollTo({top: 0, behavior: 'smooth'});
             hideHome();
             hideRecipeCards();
             showRecipePage();

--- a/source/scripts/script.js
+++ b/source/scripts/script.js
@@ -150,7 +150,7 @@ function createRecipeCards() {
 
 function bindRecipeCard(recipeCard, pageName) {
     recipeCard.addEventListener('click', e => {
-        if (e.composePath()[0].nodeName == "A") return;
+        if (e.composedPath()[0].nodeName == "A") return;
         router.navigate(pageName, false);
     });
 }

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -414,9 +414,7 @@ transform: scale(1);
   background-color: #FFECDB;
   border-radius: 20px;
   position: fixed;
-  left: 35%;
-  width:30%;
-  min-width: 400px;
+  width: 100%;
   bottom: 0%;
   display: flex;
   height: auto;
@@ -425,6 +423,13 @@ transform: scale(1);
   z-index: 100;
   transition: all ease-out 0.5s;
   transform: translateY(100%);
+}
+
+@media (min-width: 1000px) {
+  #save-cookbook-menu {
+    left: 35%;
+    max-width: 30%;
+  }
 }
 
 #cookbook-lists{

--- a/source/styles/style.css
+++ b/source/styles/style.css
@@ -477,6 +477,63 @@ transform: scale(1);
   color: var(--orange3);
 }
 
+
+/* Edit Recipe style ================================================================*/
+.edit-recipe-form {
+  position: fixed;
+  z-index: 100;
+  border-radius: 20px;
+  background: #FFECDB;
+  width:100%;
+  height: 90%;
+  margin: auto;
+  display: grid;
+  place-items: center;
+  overflow: auto;
+  top: 0%;
+  transition: all ease-out 0.5s;
+  transform: translateY(-150%);
+  opacity: 1;
+}
+
+.edit-recipe-form > div {
+  width: 70%;
+}
+
+
+.edit-recipe-form > div> button {
+  background: inherit;
+  color: inherit;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.edit-ingredients > *, .edit-instructions > * {
+  padding: .5em;
+}
+.edit-ingredients > ol > li, .edit-instructions > ol > li {
+  padding: .25em;
+  width: auto;
+}
+.edit-ingredients > ol > li > input, .edit-instructions > ol > li > input {
+  padding: 0.25em;
+  border: 0;
+  width: 100%;
+  color: black;
+}
+  
+#cancel, #submit {
+  padding: 1em 0;
+  width: 7em;
+} 
+@media (min-width: 750px) {
+  .edit-recipe-form {
+    left: 25%;
+    width: 50%;
+  }
+}
+/* end of Edit Recipe style =========================================================*/
+
 /* Category Cards style ============================================================*/
 .category-cards--wrapper{
   position: absolute;


### PR DESCRIPTION
This PR includes:

1.  Main feature:
- Allow users to edit recipes after they save recipes to Local Storage.
- After users edit a recipe, RecipePage will be reloaded with the new information that the user entered.
2. Small fixes:
- The screen will scroll up when entering the Recipe page
- RecipePage now looks better in mobile (tested on iphone)
- Saved recipes will always display data from local storage and display bookmark and edit buttons accordingly.

Other notes:
- Need help with CSS 

![image](https://user-images.githubusercontent.com/63533605/143953610-d8c0b9f0-8987-4d63-8d8d-664ba5771f24.png)
