### PR TITLE
Improve tap-mode + new layout

### DIFF
--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -17,7 +17,6 @@ class RecipePage extends HTMLElement {
       .header{
         display: block;
         text-align: center; 
-        width: 70%;
         margin: auto;
       }
 
@@ -44,17 +43,6 @@ class RecipePage extends HTMLElement {
         font-size: min(10vw, 2rem);
         text-align: center;
         line-height: max(1px, 1rem);
-      }
-
-      @media (max-width: 750px) {
-        .header h1{
-          font-size: min(10vw, 2rem);
-          letter-spacing: -1px;
-          line-height: max(1px, 2rem);
-        }
-        .header #bookmark{
-          height: max(10vw, 10px);
-        }
       }
 
       .header #bookmark{
@@ -189,70 +177,88 @@ class RecipePage extends HTMLElement {
         background: #eee;
       }
 
-      #tap-mode-section {
-        display: flex;
-        flex-direction: column;
+      .right {
+        position: fixed;
+        bottom: 0%;
+        left: 55%;
+        width: 45%;
+        height: 60%;
       }
-      #tap-mode-instr{
-        font-size: 2rem;
-        font-style: italic;
-        padding-right: 5rem;
-        padding-left: 5rem;
-        padding-bottom: 2rem;
+      .left {
+        position: fixed;
+        bottom: 0%;
+        left: 0%;
+        width: 45%;
+        height: 60%;
       }
-
-      #change-instr-btn-section {
-        padding: 20px;
-        height: fit-content;
-        display: flex;
-        flex-direction: row;
-        width: 50%;
-        position: relative;
-        left: 50%;
-        transform: translateX(-50%);
+      
+      .left:hover, .right:hover{
+        cursor: pointer;
       }
 
-      .change-instr-buttons {
-        height: max-content;
-        float:right;
-        width: 50%;
-        height: 10vh;
-        float: right;
-        background: var(--primary);
-        border: none;
-        border-radius: 5px;
-        color: white;
+      #content{
         font-size: 1rem;
+        margin: auto;
+        text-align: center;
+        overflow: hidden;
+      }
+
+      @media (min-width: 750px) {
+        #content{
+          font-size: 2rem;
+          padding: 0 20%;
+        }
       }
 
       .hidden {
         display: none;
       }
-
-      #prev-step-button {
-        margin-right: 2vw;
-        font-weight: bold;
-      }
-      #next-step-button {
-        margin-left: 2vw;
-        font-weight: bold;
-
-      }
-      
-      #prev-step-button:hover,
-      #next-step-button:hover {
-        cursor: pointer;
-        transform: scale(1.01,1.01);
-        transition: all 0.1s ease-in;
-      }
-
       @media print {
         .noprint {
            visibility: hidden;
         }
       }
+      
 
-      `;
+    `;
+
+    container.innerHTML = `
+    <header class="header">
+      <h1 id="recipe-title"></h1>
+      <img id="bookmark" class="noprint" onclick="showCookBookMenu()" src="./img/icons/bookmark-empty.svg" name="bookmark-empty" width="56" height="56" title="click to save this recipe">
+    </header>
+    <div class="edit-recipe hidden">
+      <span onclick="load()">Edit <img src="./img/icons/pencil.svg" alt="pencil" width="20" height="20"> </span>
+    </div>
+    <div class="share-icons noprint">
+      <img id="print" onclick="printRecipe()" src="./img/icons/print-icon.svg" name="print-icon" width="36" height="36">
+      <img id="email" onclick="emailRecipe()" src="./img/icons/email-icon.svg" name="email-icon" width="36" height="36">
+    </div>
+    
+    <div class="dish-image">
+      <img style="display: block; margin-left: auto; margin-right: auto;" >
+    </div>
+    
+    <main id="recipe-page-box" class="middle"> 
+        <div id="ingredients-list">
+            <h3>INGREDIENTS</h3>
+            <ul style="list-style-type: none;" id="recipe-ingredients">
+            </ul>
+            <button id="clear-checkboxes" onclick="clearCheckBoxes()" class="noprint">CLEAR CHECKBOXES</button>
+        </div>
+        <div id="instructions">
+            <h3>INSTRUCTIONS</h3>   
+            <ol id="recipe-instructions">
+            </ol>
+        </div>
+    </main>
+    <div id="tap-mode-section" class="hidden noprint">
+      <div id="content"></div>
+      <div id="alert"></div>
+      <div onclick="next()" class="right"></div>
+      <div onclick="previous()" class="left"></div>
+    </div>
+    `;
 
     this.shadowRoot.append(style, container);
   }
@@ -275,6 +281,7 @@ class RecipePage extends HTMLElement {
         <img id="print" onclick="printRecipe()" src="./img/icons/print-icon.svg" name="print-icon" width="36" height="36">
         <img id="email" onclick="emailRecipe()" src="./img/icons/email-icon.svg" name="email-icon" width="36" height="36">
       </div>
+      
       <div class="dish-image">
         <img style="display: block; margin-left: auto; margin-right: auto;" >
       </div>
@@ -292,13 +299,11 @@ class RecipePage extends HTMLElement {
               </ol>
           </div>
       </main>
-      <section id="tap-mode-section" > 
-        <div id="tap-mode-instr"></div>
-        <section id="change-instr-btn-section">        
-          <button id="prev-step-button" class="change-instr-buttons">&larr; Previous Step</button> 
-          <button id="next-step-button" class="change-instr-buttons">Next Step &rarr;</button>    
-        </section>
-      </section >
+      <div id="tap-mode-section" class="noprint" style="display:none">
+        <div id="content"></div>
+        <div class="right"></div>
+        <div class="left"></div>
+      </div>
       `;
     // TODO: move instructions on top of buttons instead
 
@@ -320,64 +325,33 @@ class RecipePage extends HTMLElement {
     });
 
     // <-- instruction -->
-    // For tap mode, display one instruction at a time
-
     const instructions = getInstructions(data);
-    const instructionSize = instructions.length;
-
-    var tapModeInd = 0;
-    const instr = getSingleInstr(instructions, tapModeInd);
-
-    const tapModeInstr = this.shadowRoot.getElementById("tap-mode-instr");
-    const recipePageBox = this.shadowRoot.getElementById("recipe-page-box");
-    const tapModeSection = this.shadowRoot.getElementById("tap-mode-section");
-    tapModeSection.style.display = "none"; //by default, tap mode is off/hidden
-    tapModeInstr.innerHTML = instr;
-
-    document.getElementById("tap-mode-button").addEventListener("click", () => {
-      tapModeSection.style.visibility = $tapModeVisibility;
-      tapModeSection.style.display = null;
-      if ($tapModeVisibility == "hidden") {
-        recipePageBox.style.display = "block";
-        tapModeSection.style.display = "none";
-      }
-      else {
-        recipePageBox.style.display = "none";
-
-      }
-    });
-
-    this.shadowRoot.getElementById("prev-step-button").addEventListener("click", () => {
-      if (tapModeInd == 0) {
-        console.log("you're on the first step already!");
-        return;
-      }
-      else {
-        tapModeInd--;
-        const instr = getSingleInstr(instructions, tapModeInd);
-        tapModeInstr.innerHTML = instr;
-      }
-    });
-
-    this.shadowRoot.getElementById("next-step-button").addEventListener("click", () => {
-      if (tapModeInd >= instructionSize - 1) {
-        console.log("You've reached the end of the recipe!");
-        return;
-      }
-      else {
-        tapModeInd++;
-        const instr = getSingleInstr(instructions, tapModeInd);
-        tapModeInstr.innerHTML = instr;
-      }
-    });
-
-    // This displays all the instructions in numbered order for non-tap mode 
     instructions.forEach(element => {
       const li = document.createElement("li");
       li.innerHTML = element;
       this.shadowRoot.querySelector("#instructions > ol").appendChild(li);
     });
 
+    // <-- tap mode section -->
+    tapMode();
+    let index = 0;
+    let instr = this.shadowRoot.querySelector("#content");
+    instr.innerHTML = `${index + 1}. ` + instructions[index];
+    this.shadowRoot.querySelector(".right").addEventListener("click", () => {
+      alert.innerHTML = "";
+      if (index !== instructions.length - 1)
+        index++;
+      instr.innerHTML = `${index + 1}. ` + instructions[index];
+    });
+
+    this.shadowRoot.querySelector(".left").addEventListener("click", () => {
+      alert.innerHTML = "";
+      if (index !== 0)
+        index--;
+
+      instr.innerHTML = `${index + 1}. ` + instructions[index];
+    });
+    
     // replicate data
     const replicateData = {
       "id": data["id"],
@@ -391,19 +365,6 @@ class RecipePage extends HTMLElement {
   get data() {
     return this.json;
   }
-}
-
-/**
- * Used for the tap mode when the user clicks next step or previous step
- *
- * @param {Array} instructions An array of instructions to send to tap mode
- * @param {Number} tapModeInd The index of the tap mode
- * @return {String} The instruction to show to tap mode
- */
-function getSingleInstr(instructions, tapModeInd) {
-  const instr = instructions[tapModeInd];
-  const instructionNum = tapModeInd + 1;
-  return instructionNum + ".  " + instr;
 }
 
 // Helper functions
@@ -443,8 +404,29 @@ function getInstructions(data) {
     let instruction = step["step"];
     instrucList[index++] = instruction;
   });
-
   return instrucList;
+}
+
+/**
+ * This function enables tap-mode
+ */
+function tapMode() {
+  const TapModeSection = document.querySelector("#recipe-page-container > recipe-page").shadowRoot.querySelector("#tap-mode-section");
+  const RecipePageBox = document.querySelector("#recipe-page-container > recipe-page").shadowRoot.querySelector("#recipe-page-box");
+  const DishImage = document.querySelector("#recipe-page-container > recipe-page").shadowRoot.querySelector("article > div.dish-image");
+  document.getElementById("tap-mode-button").addEventListener("click", () => {
+    if (TapModeSection.style.display == "none") {
+      TapModeSection.style.display = null;
+      RecipePageBox.classList.add("hidden");
+      DishImage.classList.add("hidden");
+    }
+    else {
+      TapModeSection.style.display = "none";
+      RecipePageBox.classList.remove("hidden");
+      DishImage.classList.remove("hidden");
+    }
+
+  });
 }
 
 export { getInstructions, getIngredients };

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -20,7 +20,7 @@ class RecipePage extends HTMLElement {
         margin: auto;
         width: 80vw;
         max-width: 550px;
-        margin-top: 10px;
+        margin-top: 40px;
       }
 
       .share-icons {

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -196,15 +196,19 @@ class RecipePage extends HTMLElement {
         cursor: pointer;
       }
 
-      #content{
+      #content, #alert{
         font-size: 1rem;
         margin: auto;
         text-align: center;
         overflow: hidden;
       }
 
+      #alert {
+        color: red;
+      }
+
       @media (min-width: 750px) {
-        #content{
+        #content, #alert{
           font-size: 2rem;
           padding: 0 20%;
         }
@@ -300,6 +304,7 @@ class RecipePage extends HTMLElement {
           </div>
       </main>
       <div id="tap-mode-section" class="noprint" style="display:none">
+        <div id="alert"> </div>
         <div id="content"></div>
         <div class="right"></div>
         <div class="left"></div>
@@ -336,11 +341,15 @@ class RecipePage extends HTMLElement {
     tapMode();
     let index = 0;
     let instr = this.shadowRoot.querySelector("#content");
+    let alert = this.shadowRoot.querySelector("#alert");
     instr.innerHTML = `${index + 1}. ` + instructions[index];
     this.shadowRoot.querySelector(".right").addEventListener("click", () => {
       alert.innerHTML = "";
       if (index !== instructions.length - 1)
         index++;
+      else
+        alert.innerHTML = "You've reached the end of the instructions!";
+
       instr.innerHTML = `${index + 1}. ` + instructions[index];
     });
 
@@ -348,10 +357,11 @@ class RecipePage extends HTMLElement {
       alert.innerHTML = "";
       if (index !== 0)
         index--;
-
+      else
+        alert.innerHTML = "You've reached the first instruction!";
       instr.innerHTML = `${index + 1}. ` + instructions[index];
     });
-    
+
     // replicate data
     const replicateData = {
       "id": data["id"],

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -62,8 +62,7 @@ class RecipePage extends HTMLElement {
       @media (min-width: 750px) {      
         .middle{
           display: grid;
-          grid-template-columns: auto auto;
-          text-align: center; 
+          grid-template-columns: auto auto; 
           width: 70%;
           margin: auto;
         }

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -18,6 +18,8 @@ class RecipePage extends HTMLElement {
         display: block;
         text-align: center; 
         margin: auto;
+        width: 80vw;
+        max-width: 550px;
       }
 
       .share-icons {
@@ -26,7 +28,7 @@ class RecipePage extends HTMLElement {
         justify-content: center;
         width: 100%;
         margin-top: 20px;
-        margin-bottom: 40px;
+        margin-bottom: 20px;
       }
 
       #print {
@@ -82,7 +84,7 @@ class RecipePage extends HTMLElement {
       .middle > div > h3{
           text-align: center;
           font-weight: bold;
-          margin-top: 10px;
+          margin-top: 30px;
       }
     
       #clear-checkboxes{
@@ -178,32 +180,52 @@ class RecipePage extends HTMLElement {
 
       .right {
         position: fixed;
-        bottom: 0%;
+        top: 0%;
         left: 55%;
         width: 45%;
-        height: 60%;
+        height: 100vh;
       }
+
       .left {
         position: fixed;
-        bottom: 0%;
+        top: 0%;
         left: 0%;
         width: 45%;
-        height: 60%;
+        height: 100vh;
       }
       
       .left:hover, .right:hover{
         cursor: pointer;
       }
 
-      #content, #alert{
+      #right-arrow {
+        position: absolute;
+        right: 5vw;
+        top: 50%;
+        font-size: 2rem;
+      }
+
+      #left-arrow {
+        position: absolute;
+        left: 5vw;
+        top: 50%;
+        font-size: 2rem;
+      }
+
+      #content{
         font-size: 1rem;
         margin: auto;
         text-align: center;
         overflow: hidden;
+        margin: 0px 50px;
       }
 
       #alert {
         color: red;
+        font-size: 1rem;
+        margin: auto;
+        text-align: center;
+        overflow: hidden;
       }
 
       @media (min-width: 750px) {
@@ -220,6 +242,13 @@ class RecipePage extends HTMLElement {
         .noprint {
            visibility: hidden;
         }
+      }
+
+      #tap-mode-section {
+        width: 100vw;
+        position: relative; 
+        left: 50%;
+        transform: translateX(-50%);
       }
       
 
@@ -305,11 +334,12 @@ class RecipePage extends HTMLElement {
       <div id="tap-mode-section" class="noprint" style="display:none">
         <div id="alert"> </div>
         <div id="content"></div>
-        <div class="right"></div>
         <div class="left"></div>
+        <div id="left-arrow">&#60;</div>
+        <div id="right-arrow">&#62;</div>
+        <div class="right"></div>        
       </div>
       `;
-    // TODO: move instructions on top of buttons instead
 
     this.shadowRoot.querySelector(".dish-image > img").src = data["image"];
     this.shadowRoot.querySelector(".header > h1").innerHTML = data["title"];

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -71,15 +71,12 @@ class RecipePage extends HTMLElement {
         transition: all 0.3s ease-out;
       }
 
-      @media (min-width: 750px) {
-        #instructions {
-          width: auto;
-        }
-        
+      @media (min-width: 750px) {      
         .middle{
-          display: block;
+          display: grid;
+          grid-template-columns: auto auto;
           text-align: center; 
-          width: 50%;
+          width: 70%;
           margin: auto;
         }
       }
@@ -257,34 +254,6 @@ class RecipePage extends HTMLElement {
 
       `;
 
-    container.innerHTML = `
-      <header class="header">
-        <h1 id="recipe-title"></h1>
-        <img id="bookmark" onclick="showCookBookMenu()" src="img/icons/bookmark-empty.svg" name="bookmark-empty" width="56" height="56">
-      </header>
-      <div class="edit-recipe hidden">
-        <span onclick="load()">Edit <img src="./img/icons/pencil.svg" alt="pencil" width="20" height="20"> </span>
-      </div>
-      <div class="share-icons noprint">
-        <img id="print" onclick="printRecipe()" src="./img/icons/print-icon.svg" name="print-icon" width="36" height="36">
-        <img id="email" onclick="emailRecipe()" src="./img/icons/email-icon.svg" name="email-icon" width="36" height="36">
-      </div>
-      <main class="middle">
-        <img style="display: block; margin-left: auto; margin-right: auto;">
-          <div id="ingredients-list">
-              <h3>INGREDIENTS</h3>
-              <ul style="list-style-type: none;" id="recipe-ingredients" >
-              </ul>
-              <button id="clear-checkboxes" onclick="clearCheckBoxes()">CLEAR CHECKBOXES</button>
-          </div>
-          <div id="instructions">
-              <h3>INSTRUCTIONS</h3>
-              <ol id="recipe-instructions">
-              </ol>
-          </div>
-      </main>
-      `;
-
     this.shadowRoot.append(style, container);
   }
 
@@ -306,8 +275,11 @@ class RecipePage extends HTMLElement {
         <img id="print" onclick="printRecipe()" src="./img/icons/print-icon.svg" name="print-icon" width="36" height="36">
         <img id="email" onclick="emailRecipe()" src="./img/icons/email-icon.svg" name="email-icon" width="36" height="36">
       </div>
-      <main id="recipe-page-box" class="middle">
+      <div class="dish-image">
         <img style="display: block; margin-left: auto; margin-right: auto;" >
+      </div>
+      
+      <main id="recipe-page-box" class="middle"> 
           <div id="ingredients-list">
               <h3>INGREDIENTS</h3>
               <ul style="list-style-type: none;" id="recipe-ingredients">
@@ -326,13 +298,11 @@ class RecipePage extends HTMLElement {
           <button id="prev-step-button" class="change-instr-buttons">&larr; Previous Step</button> 
           <button id="next-step-button" class="change-instr-buttons">Next Step &rarr;</button>    
         </section>
-
-        
       </section >
       `;
     // TODO: move instructions on top of buttons instead
 
-    this.shadowRoot.querySelector(".middle > img").src = data["image"];
+    this.shadowRoot.querySelector(".dish-image > img").src = data["image"];
     this.shadowRoot.querySelector(".header > h1").innerHTML = data["title"];
 
     //get ingredient list

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -20,6 +20,7 @@ class RecipePage extends HTMLElement {
         margin: auto;
         width: 80vw;
         max-width: 550px;
+        margin-top: 10px;
       }
 
       .share-icons {

--- a/source/scripts/RecipePage.js
+++ b/source/scripts/RecipePage.js
@@ -335,9 +335,9 @@ class RecipePage extends HTMLElement {
       <div id="tap-mode-section" class="noprint" style="display:none">
         <div id="alert"> </div>
         <div id="content"></div>
-        <div class="left"></div>
         <div id="left-arrow">&#60;</div>
         <div id="right-arrow">&#62;</div>
+        <div class="left"></div>
         <div class="right"></div>        
       </div>
       `;


### PR DESCRIPTION
This PR includes:
- Adapted new recipe layout.
- Enhanced tap-mode: buttons no longer in use. Users can tap on the left or right of the screen to go to the previous/next instruction.

Adjust here:
![image](https://user-images.githubusercontent.com/63533605/144701003-78559ff9-75a6-4161-a699-138a30efe7e6.png)
Areas of tap mode as shown in the image
![image](https://user-images.githubusercontent.com/63533605/144701041-5bd74c11-c4dc-4130-9bd5-748656208b41.png)
